### PR TITLE
Exclude SndOut_XAudio2.cpp for libretro builds

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -218,7 +218,7 @@ if(APPLE)
 	target_link_options(common PRIVATE -fobjc-link-runtime)
 endif()
 
-if(USE_OPENGL)
+if(USE_OPENGL AND NOT LIBRETRO)
 	if(WIN32)
 		target_sources(common PRIVATE
 			GL/ContextWGL.cpp

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1096,6 +1096,7 @@ if(LIBRETRO)
 		SPU2/SndOut.cpp
 		SPU2/SndOut_SDL.cpp
 		SPU2/SndOut_Portaudio.cpp
+		SPU2/SndOut_XAudio2.cpp
 		SPU2/Config.cpp
 		SPU2/ConfigSoundTouch.cpp
 		SPU2/Timestretcher.cpp

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1090,7 +1090,7 @@ if(LIBRETRO)
 		Frontend/InputManager.cpp
 	)
 	LIST(REMOVE_ITEM pcsx2FrontendSources
-		Frontend/DinputSource.cpp
+		Frontend/DInputSource.cpp
 		Frontend/XInputSource.cpp
 	)
 	LIST(REMOVE_ITEM pcsx2SPU2Sources

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1089,6 +1089,10 @@ if(LIBRETRO)
 		Frontend/CommonHotkeys.cpp
 		Frontend/InputManager.cpp
 	)
+	LIST(REMOVE_ITEM pcsx2FrontendSources
+		Frontend/DinputSource.cpp
+		Frontend/XInputSource.cpp
+	)
 	LIST(REMOVE_ITEM pcsx2SPU2Sources
 	#	SPU2/Debug.cpp
 	#	SPU2/Wavedump_wav.cpp


### PR DESCRIPTION
As title says.